### PR TITLE
Removed automatic triggering of Test-NuGetPackage.ps1 after pack.

### DIFF
--- a/IntelliTect.TestTools.Console.sln
+++ b/IntelliTect.TestTools.Console.sln
@@ -22,8 +22,8 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{6CC83703-96BC-4E1A-8F3D-0DA0D9FC767E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6CC83703-96BC-4E1A-8F3D-0DA0D9FC767E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6CC83703-96BC-4E1A-8F3D-0DA0D9FC767E}.Linux|Any CPU.ActiveCfg = Linux|Any CPU
-		{6CC83703-96BC-4E1A-8F3D-0DA0D9FC767E}.Linux|Any CPU.Build.0 = Linux|Any CPU
+		{6CC83703-96BC-4E1A-8F3D-0DA0D9FC767E}.Linux|Any CPU.ActiveCfg = Release|Any CPU
+		{6CC83703-96BC-4E1A-8F3D-0DA0D9FC767E}.Linux|Any CPU.Build.0 = Release|Any CPU
 		{6CC83703-96BC-4E1A-8F3D-0DA0D9FC767E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6CC83703-96BC-4E1A-8F3D-0DA0D9FC767E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{DE071D93-8F7C-4A8D-8436-0FCA0512DBB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -35,5 +35,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9EB2D55B-658A-4F4A-9413-E17ED68A5119}
 	EndGlobalSection
 EndGlobal

--- a/IntelliTect.TestTools.Console.sln
+++ b/IntelliTect.TestTools.Console.sln
@@ -1,4 +1,4 @@
-﻿
+﻿﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26228.0
@@ -22,8 +22,8 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{6CC83703-96BC-4E1A-8F3D-0DA0D9FC767E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6CC83703-96BC-4E1A-8F3D-0DA0D9FC767E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6CC83703-96BC-4E1A-8F3D-0DA0D9FC767E}.Linux|Any CPU.ActiveCfg = Release|Any CPU
-		{6CC83703-96BC-4E1A-8F3D-0DA0D9FC767E}.Linux|Any CPU.Build.0 = Release|Any CPU
+		{6CC83703-96BC-4E1A-8F3D-0DA0D9FC767E}.Linux|Any CPU.ActiveCfg = Linux|Any CPU
+		{6CC83703-96BC-4E1A-8F3D-0DA0D9FC767E}.Linux|Any CPU.Build.0 = Linux|Any CPU
 		{6CC83703-96BC-4E1A-8F3D-0DA0D9FC767E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6CC83703-96BC-4E1A-8F3D-0DA0D9FC767E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{DE071D93-8F7C-4A8D-8436-0FCA0512DBB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -35,8 +35,5 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {9EB2D55B-658A-4F4A-9413-E17ED68A5119}
 	EndGlobalSection
 EndGlobal

--- a/IntelliTect.TestTools.Console/Directory.Build.targets
+++ b/IntelliTect.TestTools.Console/Directory.Build.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="TestPackage" AfterTargets="Pack">
+  <Target Name="TestPackage">
     <Exec Command="powershell.exe -noprofile -file $(ProjectDirectory)..\Test-NuGetPackage.ps1 $(PackageOutputPath)$(PackageId).$(PackageVersion).nupkg $(AssemblyName)" />
   </Target>
   <Target Name="CopyPackage" AfterTargets="TestPackage">

--- a/IntelliTect.TestTools.Console/IntelliTect.TestTools.Console.csproj
+++ b/IntelliTect.TestTools.Console/IntelliTect.TestTools.Console.csproj
@@ -13,7 +13,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <Authors>Mark Michaelis</Authors>
-    <Version>0.5.1-beta-180924-1</Version>
+    <!--Version>0.5.1-beta-180924-1</Version-->
     <Company>IntelliTect</Company>
     <Title>IntelliTect.TestTools.Console</Title>
     <Description>Redirects the console to enable unit testing of console output and the injecting of console input.</Description>


### PR DESCRIPTION
The script for running Read-Archive does not seem to be compatible with native PowerShell. Directory.Build.targets Target name TestPackage has been left in so that it can be invoked manually