### PR TITLE
Minor browser updates

### DIFF
--- a/IntelliTect.TestTools.Selenate/GoogleSearch/ExampleTests.cs
+++ b/IntelliTect.TestTools.Selenate/GoogleSearch/ExampleTests.cs
@@ -38,7 +38,7 @@ namespace GoogleSearch
         {
             await Google.SearchForItem("selenium automation");
             await Google.GoToHomePage();
-            Assert.IsFalse(await Browser.WaitUntil(() => Harness.SearchResultsDiv.Displayed),
+            Assert.IsFalse(await Browser.WaitForExpectedState(() => Harness.SearchResultsDiv.Displayed, expectedResult: false),
                 "Search results displayed when they were not expected");
         }
 

--- a/IntelliTect.TestTools.Selenate/GoogleSearch/ExampleTests.cs
+++ b/IntelliTect.TestTools.Selenate/GoogleSearch/ExampleTests.cs
@@ -38,7 +38,7 @@ namespace GoogleSearch
         {
             await Google.SearchForItem("selenium automation");
             await Google.GoToHomePage();
-            Assert.IsFalse(await Browser.WaitForExpectedState(() => Harness.SearchResultsDiv.Displayed, expectedResult: false),
+            Assert.IsFalse(await Browser.IsElementInExpectedState(() => Harness.SearchResultsDiv.Displayed, expectedResult: false),
                 "Search results displayed when they were not expected");
         }
 

--- a/IntelliTect.TestTools.Selenate/GoogleSearch/ExampleTests.cs
+++ b/IntelliTect.TestTools.Selenate/GoogleSearch/ExampleTests.cs
@@ -29,7 +29,7 @@ namespace GoogleSearch
         public async Task VerifySeleniumDoesNotExistForElement()
         {
             await Google.SearchForItem("selenium element");
-            Assert.IsFalse(await Google.FindSearchResultItem("Selenium - Web Browser Automation"),
+            Assert.IsFalse(await Google.FindSearchResultItem("Selenium - Web Browser Automation", false),
                 "Found a specific search result for Selenium - Web Browser Automation when none was expected");
         }
 

--- a/IntelliTect.TestTools.Selenate/GoogleSearch/GoogleFunctions.cs
+++ b/IntelliTect.TestTools.Selenate/GoogleSearch/GoogleFunctions.cs
@@ -22,11 +22,10 @@ namespace GoogleSearch
             return await Browser.IsElementInExpectedState(() => Harness.SearchResultsDiv.Displayed);
         }
 
-        public Task<bool> FindSearchResultItem(string result)
+        public Task<bool> FindSearchResultItem(string result, bool itemExists = true)
         {
             // Don't need to await this since it would just be on one line
-            var headers = Harness.SearchResultsHeadersList;
-            return Browser.IsElementInExpectedState(() => headers.Any(h => h.Text == result));
+            return Browser.IsElementInExpectedState(() => Harness.SearchResultsHeadersList.Any(h => h.Text == result), itemExists);
         }
 
         public async Task<bool> GoToHomePage()

--- a/IntelliTect.TestTools.Selenate/GoogleSearch/GoogleFunctions.cs
+++ b/IntelliTect.TestTools.Selenate/GoogleSearch/GoogleFunctions.cs
@@ -19,20 +19,20 @@ namespace GoogleSearch
             Browser.Driver.Navigate().GoToUrl(Harness.URL);
             await Harness.SearchInput.FillInWithWhenReady(searchItem);
             Harness.SearchInput.SendKeys(Keys.Return);
-            return await Browser.WaitUntil(() => Harness.SearchResultsDiv.Displayed);
+            return await Browser.WaitForExpectedState(() => Harness.SearchResultsDiv.Displayed);
         }
 
         public Task<bool> FindSearchResultItem(string result)
         {
             // Don't need to await this since it would just be on one line
             var headers = Harness.SearchResultsHeadersList;
-            return Browser.WaitUntil(() => headers.Any(h => h.Text == result));
+            return Browser.WaitForExpectedState(() => headers.Any(h => h.Text == result));
         }
 
         public async Task<bool> GoToHomePage()
         {
             await Harness.GoHomeButton.Result.ClickWhenReady();
-            return await Browser.WaitUntil(() => Harness.GoogleSearchButton.Displayed);
+            return await Browser.WaitForExpectedState(() => Harness.GoogleSearchButton.Displayed);
         }
 
         private GoogleBrowser Browser { get; }

--- a/IntelliTect.TestTools.Selenate/GoogleSearch/GoogleFunctions.cs
+++ b/IntelliTect.TestTools.Selenate/GoogleSearch/GoogleFunctions.cs
@@ -19,20 +19,20 @@ namespace GoogleSearch
             Browser.Driver.Navigate().GoToUrl(Harness.URL);
             await Harness.SearchInput.FillInWithWhenReady(searchItem);
             Harness.SearchInput.SendKeys(Keys.Return);
-            return await Browser.WaitForExpectedState(() => Harness.SearchResultsDiv.Displayed);
+            return await Browser.IsElementInExpectedState(() => Harness.SearchResultsDiv.Displayed);
         }
 
         public Task<bool> FindSearchResultItem(string result)
         {
             // Don't need to await this since it would just be on one line
             var headers = Harness.SearchResultsHeadersList;
-            return Browser.WaitForExpectedState(() => headers.Any(h => h.Text == result));
+            return Browser.IsElementInExpectedState(() => headers.Any(h => h.Text == result));
         }
 
         public async Task<bool> GoToHomePage()
         {
             await Harness.GoHomeButton.Result.ClickWhenReady();
-            return await Browser.WaitForExpectedState(() => Harness.GoogleSearchButton.Displayed);
+            return await Browser.IsElementInExpectedState(() => Harness.GoogleSearchButton.Displayed);
         }
 
         private GoogleBrowser Browser { get; }

--- a/IntelliTect.TestTools.Selenate/GoogleSearch/GoogleHarness.cs
+++ b/IntelliTect.TestTools.Selenate/GoogleSearch/GoogleHarness.cs
@@ -18,7 +18,7 @@ namespace GoogleSearch
         public IWebElement SearchResultsDiv =>
                 Browser.FindElement(By.CssSelector("div[data-async-context^='query:']"));
         public IReadOnlyCollection<IWebElement> SearchResultsHeadersList => 
-            Browser.FindElements(By.CssSelector("div[id='rso']>div div[class='g'] div[class='rc']>h3>a")).GetAwaiter().GetResult();
+            Browser.FindElements(By.CssSelector("div[id='rso']>div div[class='g'] div[class='rc'] h3")).GetAwaiter().GetResult();
         public Task<IWebElement> GoHomeButton => Browser.FindElementAsync(By.CssSelector("div[class='logo']"));
 
         private GoogleBrowser Browser { get; }

--- a/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate/Browser.cs
+++ b/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate/Browser.cs
@@ -79,7 +79,8 @@ namespace IntelliTect.TestTools.Selenate
         }
 
         /// <summary>
-        ///Waits until a function evaluates to true OR times out after a specified period of time
+        /// Waits until a function evaluates and returns the results OR fails after a specified period of time.
+        /// NoSuchElement, StaleElement, ElementNotVisible, and InvalidElementState exceptions will return a result of false while all other exceptions will immediately throw
         /// </summary>
         /// <param name="func">Function to evaluate</param>
         /// <param name="secondsToWait">Seconds to wait until timeout / return false</param>
@@ -88,19 +89,12 @@ namespace IntelliTect.TestTools.Selenate
         {
             try
             {
-                if (await Wait.Until<
-                NoSuchElementException,
-                StaleElementReferenceException,
-                ElementNotVisibleException,
-                InvalidElementStateException,
-                bool>(func, TimeSpan.FromSeconds(secondsToWait)))
-                {
-                    return true;
-                }
-                else
-                {
-                    return false;
-                }
+                return await Wait.Until<
+                    NoSuchElementException,
+                    StaleElementReferenceException,
+                    ElementNotVisibleException,
+                    InvalidElementStateException,
+                    bool>( func, TimeSpan.FromSeconds( secondsToWait ) );
             }
             catch (AggregateException) // Worth checking for specific inner exceptions?
             {

--- a/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate/Browser.cs
+++ b/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate/Browser.cs
@@ -82,31 +82,28 @@ namespace IntelliTect.TestTools.Selenate
         public async Task<bool> IsElementInExpectedState(Func<bool> func, bool expectedResult = true, int secondsToWait = 15)
         {
             bool result;
-            Stopwatch sw = new Stopwatch();
-            sw.Start();
-
-            do
+            try
             {
-                try
-                {
-                    result = await Wait.Until<
+                return await Wait.Until<
                     NoSuchElementException,
                     StaleElementReferenceException,
                     ElementNotVisibleException,
                     InvalidElementStateException,
-                    bool>(func, TimeSpan.FromSeconds(secondsToWait));
-                }
-                catch (AggregateException)
-                {
-                    result = false;
-                }
-                if (result == expectedResult)
-                {
-                    return result;
-                }
-            } while (sw.Elapsed < TimeSpan.FromSeconds(secondsToWait));
+                    bool>(CheckForExpectedResult, TimeSpan.FromSeconds(secondsToWait));
+            }
+            catch (AggregateException)
+            {
+                result = false;
+            }
 
-            return !result;
+            return result;
+
+            // Using a local function purely for code conciseness above. Move to it's own method if this is ever needed by other checks.
+            bool CheckForExpectedResult()
+            {
+                bool r;
+                return (r = func()) == expectedResult ? r : throw new InvalidElementStateException();
+            }
         }
 
         /// <summary>

--- a/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate.csproj
+++ b/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate.csproj
@@ -15,9 +15,10 @@
     <RepositoryUrl>https://github.com/IntelliTect/TestTools/tree/master/IntelliTect.TestTools.Selenate</RepositoryUrl>
     <RepositoryType />
     <PackageTags>selenium, ui test, automated test, testing, web test</PackageTags>
-    <PackageReleaseNotes>Minor update to how Browser.WaitUntil works. Was using an old, prototype version before the underlying wait had a type return.</PackageReleaseNotes>
+    <PackageReleaseNotes>Found additional issues with Browser.WaitUntil. Deprecating in favor of a new method: IsElementInExpectedState, which has an argument for the result you expect back so that we know how to handle exceptions</PackageReleaseNotes>
     <Version>1.0.2</Version>
-    <AssemblyVersion>1.0.2.0</AssemblyVersion>
+    <AssemblyVersion>1.0.3.0</AssemblyVersion>
+    <FileVersion>1.0.3.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate.csproj
+++ b/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate.csproj
@@ -16,7 +16,7 @@
     <RepositoryType />
     <PackageTags>selenium, ui test, automated test, testing, web test</PackageTags>
     <PackageReleaseNotes>Found additional issues with Browser.WaitUntil. Deprecating in favor of a new method: IsElementInExpectedState, which has an argument for the result you expect back so that we know how to handle exceptions</PackageReleaseNotes>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <AssemblyVersion>1.0.3.0</AssemblyVersion>
     <FileVersion>1.0.3.0</FileVersion>
   </PropertyGroup>

--- a/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate.csproj
+++ b/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate.csproj
@@ -15,8 +15,9 @@
     <RepositoryUrl>https://github.com/IntelliTect/TestTools/tree/master/IntelliTect.TestTools.Selenate</RepositoryUrl>
     <RepositoryType />
     <PackageTags>selenium, ui test, automated test, testing, web test</PackageTags>
-    <PackageReleaseNotes>Initial release</PackageReleaseNotes>
-    <Version>1.0.1</Version>
+    <PackageReleaseNotes>Minor update to how Browser.WaitUntil works. Was using an old, prototype version before the underlying wait had a type return.</PackageReleaseNotes>
+    <Version>1.0.2</Version>
+    <AssemblyVersion>1.0.2.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update to Browser.WaitUntil. It was using an old version of the logic from before we could specify a return type. This version should be more accurate for 80% - 90% of all scenarios in Selenium.