### PR TITLE
Addtl SendKeys fix

### DIFF
--- a/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate/ElementHandler.cs
+++ b/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate/ElementHandler.cs
@@ -1,9 +1,6 @@
 ﻿using OpenQA.Selenium;
 using OpenQA.Selenium.Support.UI;
 using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace IntelliTect.TestTools.Selenate
 {
@@ -64,6 +61,7 @@ namespace IntelliTect.TestTools.Selenate
             wait.Until(sk => {
                 element.Clear();
                 element.SendKeys(textToSend);
+                System.Threading.Tasks.Task.Delay(250).Wait();
                 return element.GetAttribute("value") == textToSend;
             });
         }


### PR DESCRIPTION
Found a situation where a website is clearing the values in forms sent to it immediately after having the values input (but only the first time; something is probably loading in the background.) Wait for 250ms before checking for the correct value to capture this.