### PR TITLE
Add option to strip VT100 characters

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<PropertyGroup>
 		<Company>IntelliTect</Company>
-		<Copyright>Copyright IntelliTect © 2019, All Rights Reserved.</Copyright>
+		<Copyright>Copyright IntelliTect © 2020, All Rights Reserved.</Copyright>
 		<DefaultLanguage>en-US</DefaultLanguage>
 		<LangVersion>latest</LangVersion>
 
@@ -19,6 +19,6 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="$(IsPackable) == 'true'">
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All"/>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
 	</ItemGroup>
 </Project>

--- a/IntelliTect.TestTools.Console.Tests/ConsoleAssertTests.cs
+++ b/IntelliTect.TestTools.Console.Tests/ConsoleAssertTests.cs
@@ -52,17 +52,20 @@ namespace IntelliTect.TestTools.Console.Tests
         }
 
         [TestMethod]
-        [DataRow(@"[49mMontoya", "Montoya")]
-        [DataRow("Inigo[49mMontoya", "InigoMontoya")]
-        [DataRow("Inigo[49m", "Inigo")]
-        [DataRow("[49m", "")]
-        [DataRow("[101mMontoya", "Montoya")]
-        public void ConsoleTester_StringWithVT100Characters_VT100Stripped(string input, string expected)
+        [DataRow("\u001b[49mMontoya", "Montoya", true)]
+        [DataRow("Inigo\u001b[49mMontoya", "InigoMontoya", true)]
+        [DataRow("Inigo\u001b[49m", "Inigo", true)]
+        [DataRow("\u001b[49m", "", true)]
+        [DataRow("\u001b[101mMontoya", "Montoya", true)]
+        [DataRow("\u001b[101mMontoya", "\u001b[101mMontoya", false)]
+        public void ConsoleTester_StringWithVT100Characters_VT100Stripped(string input, 
+            string expected, 
+            bool stripVT100)
         {
             ConsoleAssert.Expect(expected, () =>
             {
                 System.Console.WriteLine(input);
-            }, stripVT100: true);
+            }, stripVT100: stripVT100);
         }
 
         [TestMethod]

--- a/IntelliTect.TestTools.Console.Tests/ConsoleAssertTests.cs
+++ b/IntelliTect.TestTools.Console.Tests/ConsoleAssertTests.cs
@@ -26,7 +26,7 @@ namespace IntelliTect.TestTools.Console.Tests
                 string lname = System.Console.ReadLine();
 
                 System.Console.Write("Hello, {0} {1}.", fname, lname);
-            });
+            }, NormalizeOptions.None);
         }
 
         [TestMethod]
@@ -37,7 +37,7 @@ namespace IntelliTect.TestTools.Console.Tests
             ConsoleAssert.Expect(view, () =>
             {
                 System.Console.Write("Hello World");
-            });
+            }, NormalizeOptions.None);
         }
 
         [TestMethod]
@@ -48,7 +48,7 @@ namespace IntelliTect.TestTools.Console.Tests
             ConsoleAssert.Expect(view, () =>
             {
                 System.Console.WriteLine("Hello World");
-            }, true);
+            }, NormalizeOptions.NormalizeLineEndings);
         }
 
         [TestMethod]
@@ -65,7 +65,7 @@ namespace IntelliTect.TestTools.Console.Tests
             ConsoleAssert.Expect(expected, () =>
             {
                 System.Console.WriteLine(input);
-            }, stripVT100: stripVT100);
+            }, NormalizeOptions.StripVt100 | NormalizeOptions.NormalizeLineEndings);
         }
 
         [TestMethod]
@@ -79,7 +79,7 @@ End";
                 System.Console.WriteLine("Begin");
                 System.Console.WriteLine("Middle");
                 System.Console.WriteLine("End");
-            }, true);
+            }, NormalizeOptions.NormalizeLineEndings);
         }
 
         [TestMethod]
@@ -90,7 +90,7 @@ End";
             ConsoleAssert.Expect(view, () =>
             {
                 System.Console.Write("Hello World");
-            }, true);
+            }, NormalizeOptions.NormalizeLineEndings);
         }
 
         [TestMethod]
@@ -102,7 +102,7 @@ End";
             ConsoleAssert.Expect(view, () =>
             {
                 System.Console.WriteLine("Hello World");
-            });
+            }, NormalizeOptions.None);
         }
 
         [TestMethod]

--- a/IntelliTect.TestTools.Console.Tests/ConsoleAssertTests.cs
+++ b/IntelliTect.TestTools.Console.Tests/ConsoleAssertTests.cs
@@ -65,7 +65,7 @@ namespace IntelliTect.TestTools.Console.Tests
             ConsoleAssert.Expect(expected, () =>
             {
                 System.Console.WriteLine(input);
-            }, NormalizeOptions.StripVt100 | NormalizeOptions.NormalizeLineEndings);
+            }, NormalizeOptions.StripAnsiEscapeCodes | NormalizeOptions.NormalizeLineEndings);
         }
 
         [TestMethod]

--- a/IntelliTect.TestTools.Console.Tests/ConsoleAssertTests.cs
+++ b/IntelliTect.TestTools.Console.Tests/ConsoleAssertTests.cs
@@ -69,6 +69,18 @@ namespace IntelliTect.TestTools.Console.Tests
         }
 
         [TestMethod]
+        public void ConsoleTester_ExplicitStrippingExplicitly_VT100Stripped()
+        {
+            string input = "\u001b[49mMontoya";
+            string expected = "Montoya";
+
+            ConsoleAssert.Expect(expected, () =>
+            {
+                System.Console.Write(input);
+            }, NormalizeOptions.StripAnsiEscapeCodes);
+        }
+
+        [TestMethod]
         public void GivenStringLiteral_ExpectedOutputNormalized_OutputMatches()
         {
             const string view = @"Begin

--- a/IntelliTect.TestTools.Console.Tests/ConsoleAssertTests.cs
+++ b/IntelliTect.TestTools.Console.Tests/ConsoleAssertTests.cs
@@ -52,6 +52,20 @@ namespace IntelliTect.TestTools.Console.Tests
         }
 
         [TestMethod]
+        [DataRow(@"[49mMontoya", "Montoya")]
+        [DataRow("Inigo[49mMontoya", "InigoMontoya")]
+        [DataRow("Inigo[49m", "Inigo")]
+        [DataRow("[49m", "")]
+        [DataRow("[101mMontoya", "Montoya")]
+        public void ConsoleTester_StringWithVT100Characters_VT100Stripped(string input, string expected)
+        {
+            ConsoleAssert.Expect(expected, () =>
+            {
+                System.Console.WriteLine(input);
+            }, stripVT100: true);
+        }
+
+        [TestMethod]
         public void GivenStringLiteral_ExpectedOutputNormalized_OutputMatches()
         {
             const string view = @"Begin

--- a/IntelliTect.TestTools.Console.Tests/ConsoleAssertTests.cs
+++ b/IntelliTect.TestTools.Console.Tests/ConsoleAssertTests.cs
@@ -26,7 +26,7 @@ namespace IntelliTect.TestTools.Console.Tests
                 string lname = System.Console.ReadLine();
 
                 System.Console.Write("Hello, {0} {1}.", fname, lname);
-            }, NormalizeOptions.None);
+            });
         }
 
         [TestMethod]
@@ -48,7 +48,7 @@ namespace IntelliTect.TestTools.Console.Tests
             ConsoleAssert.Expect(view, () =>
             {
                 System.Console.WriteLine("Hello World");
-            }, NormalizeOptions.NormalizeLineEndings);
+            });
         }
 
         [TestMethod]
@@ -65,7 +65,7 @@ namespace IntelliTect.TestTools.Console.Tests
             ConsoleAssert.Expect(expected, () =>
             {
                 System.Console.WriteLine(input);
-            }, NormalizeOptions.StripAnsiEscapeCodes | NormalizeOptions.NormalizeLineEndings);
+            });
         }
 
         [TestMethod]
@@ -79,7 +79,7 @@ End";
                 System.Console.WriteLine("Begin");
                 System.Console.WriteLine("Middle");
                 System.Console.WriteLine("End");
-            }, NormalizeOptions.NormalizeLineEndings);
+            });
         }
 
         [TestMethod]
@@ -90,7 +90,21 @@ End";
             ConsoleAssert.Expect(view, () =>
             {
                 System.Console.Write("Hello World");
-            }, NormalizeOptions.NormalizeLineEndings);
+            });
+        }
+        
+        [TestMethod]
+        public void ConsoleTester_HelloWorld_DontNormalizeCRLF()
+        {
+            const string view = "Hello World\r\n";
+            
+            Assert.ThrowsException<Exception>(() =>
+            {
+                ConsoleAssert.Expect(view, () =>
+                {
+                    System.Console.Write("Hello World\r");
+                }, NormalizeOptions.None);
+            });
         }
 
         [TestMethod]

--- a/IntelliTect.TestTools.Console.Tests/IntelliTect.TestTools.Console.Tests.csproj
+++ b/IntelliTect.TestTools.Console.Tests/IntelliTect.TestTools.Console.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <ProductName>IntelliTect.TestTools.Console.Tests</ProductName>
   </PropertyGroup>
   

--- a/IntelliTect.TestTools.Console/ConsoleAssert.cs
+++ b/IntelliTect.TestTools.Console/ConsoleAssert.cs
@@ -44,7 +44,7 @@ namespace IntelliTect.TestTools.Console
         /// <param name="normalizeOptions">Options to normalize input and expected output</param>
         public static string Expect(string expected,
             Action action, 
-            NormalizeOptions normalizeOptions = NormalizeOptions.NormalizeAll)
+            NormalizeOptions normalizeOptions = NormalizeOptions.Default)
         {
             return Expect(expected, 
                 action, 
@@ -92,7 +92,7 @@ namespace IntelliTect.TestTools.Console
         /// <param name="normalizeOptions">Options to normalize input and expected output</param>
         public static string Expect(string expected, 
             Action<string[]> action, 
-            NormalizeOptions normalizeOptions = NormalizeOptions.NormalizeAll, 
+            NormalizeOptions normalizeOptions = NormalizeOptions.Default, 
             params string[] args)
         {
             return Expect(expected, 
@@ -197,7 +197,7 @@ namespace IntelliTect.TestTools.Console
         /// <param name="equivalentOperatorErrorMessage">A textual description of the message if the result of <paramref name="action"/> does not match the <paramref name="expected"/> value</param>
         private static string Expect(
             string expected, Action action, Func<string, string, bool> comparisonOperator,
-            NormalizeOptions normalizeOptions = NormalizeOptions.NormalizeAll, 
+            NormalizeOptions normalizeOptions = NormalizeOptions.Default, 
             string equivalentOperatorErrorMessage= "Values are not equal")
         {
             (string input, string output) = Parse(expected);
@@ -261,7 +261,7 @@ namespace IntelliTect.TestTools.Console
         /// <param name="escapeCharacter">The escape character for the wildcard caracters.  Default is '\'.</param>
         public static string ExpectLike(string expected, 
             Action action, 
-            NormalizeOptions normalizeLineEndings = NormalizeOptions.NormalizeAll, 
+            NormalizeOptions normalizeLineEndings = NormalizeOptions.Default, 
             char escapeCharacter = '\\')
         {
             return Expect(expected, 
@@ -313,7 +313,7 @@ namespace IntelliTect.TestTools.Console
             string expectedOutput,
             Action action,
             Func<string, string, bool> areEquivalentOperator,
-            NormalizeOptions normalizeOptions = NormalizeOptions.NormalizeAll,
+            NormalizeOptions normalizeOptions = NormalizeOptions.Default,
             string equivalentOperatorErrorMessage = "Values are not equal"
         )
         {

--- a/IntelliTect.TestTools.Console/ConsoleAssert.cs
+++ b/IntelliTect.TestTools.Console/ConsoleAssert.cs
@@ -44,8 +44,7 @@ namespace IntelliTect.TestTools.Console
         /// <param name="normalizeOptions">Options to normalize input and expected output</param>
         public static string Expect(string expected,
             Action action, 
-            NormalizeOptions normalizeOptions 
-                = NormalizeOptions.NormalizeLineEndings | NormalizeOptions.StripAnsiEscapeCodes)
+            NormalizeOptions normalizeOptions = NormalizeOptions.NormalizeAll)
         {
             return Expect(expected, 
                 action, 
@@ -93,7 +92,7 @@ namespace IntelliTect.TestTools.Console
         /// <param name="normalizeOptions">Options to normalize input and expected output</param>
         public static string Expect(string expected, 
             Action<string[]> action, 
-            NormalizeOptions normalizeOptions, 
+            NormalizeOptions normalizeOptions = NormalizeOptions.NormalizeAll, 
             params string[] args)
         {
             return Expect(expected, 
@@ -122,7 +121,7 @@ namespace IntelliTect.TestTools.Console
         public static void Expect<T>(string expected, Func<string[], T> func, T expectedReturn = default, params string[] args)
         {
             T @return = default;
-            Expect(expected, () => @return = func(args), NormalizeOptions.None);
+            Expect(expected, () => @return = func(args));
 
             if (!expectedReturn.Equals(@return))
             {
@@ -182,7 +181,7 @@ namespace IntelliTect.TestTools.Console
         /// <param name="func">Method to be run</param>
         /// <param name="args">Args to pass to the function.</param>
         public static void Expect(string expected, Action<string[]> func, params string[] args) =>
-            Expect(expected, () => func(args), NormalizeOptions.NormalizeLineEndings);
+            Expect(expected, () => func(args));
 
         /// <summary>
         /// Performs a unit test on a console-based method. A "view" of
@@ -198,7 +197,7 @@ namespace IntelliTect.TestTools.Console
         /// <param name="equivalentOperatorErrorMessage">A textual description of the message if the result of <paramref name="action"/> does not match the <paramref name="expected"/> value</param>
         private static string Expect(
             string expected, Action action, Func<string, string, bool> comparisonOperator,
-            NormalizeOptions normalizeOptions = NormalizeOptions.NormalizeLineEndings, 
+            NormalizeOptions normalizeOptions = NormalizeOptions.NormalizeAll, 
             string equivalentOperatorErrorMessage= "Values are not equal")
         {
             (string input, string output) = Parse(expected);
@@ -238,13 +237,37 @@ namespace IntelliTect.TestTools.Console
         /// <param name="action">Method to be run</param>
         /// <param name="normalizeLineEndings">Whether differences in line ending styles should be ignored.</param>
         /// <param name="escapeCharacter">The escape character for the wildcard caracters.  Default is '\'.</param>
+        [Obsolete]
         public static string ExpectLike(string expected, Action action, 
-            bool normalizeLineEndings = true, char escapeCharacter = '\\')
+            bool normalizeLineEndings, char escapeCharacter = '\\')
         {
             return Expect(expected, 
                 action, 
                 (pattern, output) => output.IsLike(pattern, escapeCharacter),
                 normalizeLineEndings ? NormalizeOptions.NormalizeLineEndings : NormalizeOptions.None, 
+                "The values are not like (using wildcards) each other");
+        }
+        
+        /// <summary>
+        /// Performs a unit test on a console-based method. A "view" of
+        /// what a user would see in their console is provided as a string,
+        /// where their input (including line-breaks) is surrounded by double
+        /// less-than/greater-than signs, like so: "Input please: &lt;&lt;Input&gt;&gt;"
+        /// </summary>
+        /// <param name="expected">Expected "view" to be seen on the console,
+        /// including both input and output</param>
+        /// <param name="action">Method to be run</param>
+        /// <param name="normalizeLineEndings">Whether differences in line ending styles should be ignored.</param>
+        /// <param name="escapeCharacter">The escape character for the wildcard caracters.  Default is '\'.</param>
+        public static string ExpectLike(string expected, 
+            Action action, 
+            NormalizeOptions normalizeLineEndings = NormalizeOptions.NormalizeAll, 
+            char escapeCharacter = '\\')
+        {
+            return Expect(expected, 
+                action, 
+                (pattern, output) => output.IsLike(pattern, escapeCharacter),
+                normalizeLineEndings, 
                 "The values are not like (using wildcards) each other");
         }
 
@@ -286,10 +309,13 @@ namespace IntelliTect.TestTools.Console
         /// <param name="areEquivalentOperator">delegate for comparing the expected from actual output.</param>
         /// <param name="normalizeOptions">Options to normalize input and expected output</param>
         /// <param name="equivalentOperatorErrorMessage">A textual description of the message if the <paramref name="areEquivalentOperator"/> returns false</param>
-        private static string Execute(string givenInput, string expectedOutput, Action action,
-            Func<string, string, bool> areEquivalentOperator, 
-            NormalizeOptions normalizeOptions, string equivalentOperatorErrorMessage = "Values are not equal"
-            )
+        private static string Execute(string givenInput,
+            string expectedOutput,
+            Action action,
+            Func<string, string, bool> areEquivalentOperator,
+            NormalizeOptions normalizeOptions = NormalizeOptions.NormalizeAll,
+            string equivalentOperatorErrorMessage = "Values are not equal"
+        )
         {
             string output = Execute(givenInput, action);
 

--- a/IntelliTect.TestTools.Console/ConsoleAssert.cs
+++ b/IntelliTect.TestTools.Console/ConsoleAssert.cs
@@ -9,7 +9,7 @@ using System.CodeDom;
 namespace IntelliTect.TestTools.Console
 {
     /// <summary>
-    /// Provides assertion methods for tests that 
+    /// Provides assertion methods for tests that use Console Output
     /// </summary>
     public static class ConsoleAssert
     {
@@ -23,7 +23,7 @@ namespace IntelliTect.TestTools.Console
         /// including both input and output</param>
         /// <param name="action">Method to be run</param>
         /// <param name="normalizeLineEndings">Whether differences in line ending styles should be ignored.</param>
-        [Obsolete]
+        [Obsolete("Use Expect with " + nameof(NormalizeOptions))]
         public static string Expect(string expected, Action action, bool normalizeLineEndings = true)
         {
             return Expect(expected, 
@@ -42,7 +42,7 @@ namespace IntelliTect.TestTools.Console
         /// including both input and output</param>
         /// <param name="action">Method to be run</param>
         /// <param name="normalizeOptions">Options to normalize input and expected output</param>
-        public static string Expect(string expected, 
+        public static string Expect(string expected,
             Action action, 
             NormalizeOptions normalizeOptions)
         {
@@ -65,7 +65,7 @@ namespace IntelliTect.TestTools.Console
         /// <param name="action">Method to be run</param>
         /// <param name="args">Args to pass to the function.</param>
         /// <param name="normalizeLineEndings">Whether differences in line ending styles should be ignored.</param>
-        [Obsolete]
+        [Obsolete("Use Expect with " + nameof(NormalizeOptions))]
         public static string Expect(string expected, 
             Action<string[]> action, 
             bool normalizeLineEndings = true, 
@@ -181,7 +181,7 @@ namespace IntelliTect.TestTools.Console
         /// <param name="func">Method to be run</param>
         /// <param name="args">Args to pass to the function.</param>
         public static void Expect(string expected, Action<string[]> func, params string[] args) =>
-            Expect(expected, () => func(args), NormalizeOptions.None);
+            Expect(expected, () => func(args), NormalizeOptions.NormalizeLineEndings);
 
         /// <summary>
         /// Performs a unit test on a console-based method. A "view" of
@@ -271,7 +271,7 @@ namespace IntelliTect.TestTools.Console
         /// </summary>
         /// <param name="input">The input to strip</param>
         /// <returns>The stripped input.</returns>
-        public static string StripVT100(string input)
+        private static string StripAnsiEscapeCodes(string input)
         {
             return Regex.Replace(input, @"\u001b\[\d{1,3}m", "");
         }
@@ -298,10 +298,10 @@ namespace IntelliTect.TestTools.Console
                 expectedOutput = NormalizeLineEndings(expectedOutput, true);
             }
 
-            if ((normalizeOptions & NormalizeOptions.StripVt100) != 0)
+            if ((normalizeOptions & NormalizeOptions.StripAnsiEscapeCodes) != 0)
             {
-                output = StripVT100(output);
-                expectedOutput = StripVT100(expectedOutput);
+                output = StripAnsiEscapeCodes(output);
+                expectedOutput = StripAnsiEscapeCodes(expectedOutput);
             }
 
             AssertExpectation(expectedOutput, output, areEquivalentOperator, equivalentOperatorErrorMessage);

--- a/IntelliTect.TestTools.Console/ConsoleAssert.cs
+++ b/IntelliTect.TestTools.Console/ConsoleAssert.cs
@@ -24,7 +24,7 @@ namespace IntelliTect.TestTools.Console
         /// <param name="action">Method to be run</param>
         /// <param name="normalizeLineEndings">Whether differences in line ending styles should be ignored.</param>
         [Obsolete("Use Expect with " + nameof(NormalizeOptions))]
-        public static string Expect(string expected, Action action, bool normalizeLineEndings = true)
+        public static string Expect(string expected, Action action, bool normalizeLineEndings)
         {
             return Expect(expected, 
                 action, 
@@ -44,7 +44,8 @@ namespace IntelliTect.TestTools.Console
         /// <param name="normalizeOptions">Options to normalize input and expected output</param>
         public static string Expect(string expected,
             Action action, 
-            NormalizeOptions normalizeOptions)
+            NormalizeOptions normalizeOptions 
+                = NormalizeOptions.NormalizeLineEndings | NormalizeOptions.StripAnsiEscapeCodes)
         {
             return Expect(expected, 
                 action, 

--- a/IntelliTect.TestTools.Console/NormalizeOptions.cs
+++ b/IntelliTect.TestTools.Console/NormalizeOptions.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace IntelliTect.TestTools.Console
+{
+    /// <summary>
+    /// Provides available options for normalizing expected input and output
+    /// </summary>
+    [Flags]
+    public enum NormalizeOptions
+    {
+        /// <summary>
+        /// Whether VT100 color code characters should be ignored.
+        /// </summary>
+        None = 0,
+        
+        /// <summary>
+        /// Whether differences in line ending styles should be ignored.
+        /// </summary>
+        NormalizeLineEndings = 1,
+        
+        /// <summary>
+        /// No normalization
+        /// </summary>
+        StripVt100 = 2,
+    }
+}

--- a/IntelliTect.TestTools.Console/NormalizeOptions.cs
+++ b/IntelliTect.TestTools.Console/NormalizeOptions.cs
@@ -16,7 +16,7 @@ namespace IntelliTect.TestTools.Console
         /// <summary>
         /// Apply all available normalization (currently NormalizeLineEndings and StripAnsiEscapeCodes).
         /// </summary>
-        NormalizeAll = NormalizeLineEndings | StripAnsiEscapeCodes,
+        Default = NormalizeLineEndings | StripAnsiEscapeCodes,
 
         /// <summary>
         /// Whether differences in line ending styles should be ignored.

--- a/IntelliTect.TestTools.Console/NormalizeOptions.cs
+++ b/IntelliTect.TestTools.Console/NormalizeOptions.cs
@@ -14,6 +14,11 @@ namespace IntelliTect.TestTools.Console
         None = 0,
         
         /// <summary>
+        /// Apply all available normalization (currently NormalizeLineEndings and StripAnsiEscapeCodes).
+        /// </summary>
+        NormalizeAll = NormalizeLineEndings | StripAnsiEscapeCodes,
+
+        /// <summary>
         /// Whether differences in line ending styles should be ignored.
         /// </summary>
         NormalizeLineEndings = 1,

--- a/IntelliTect.TestTools.Console/NormalizeOptions.cs
+++ b/IntelliTect.TestTools.Console/NormalizeOptions.cs
@@ -9,7 +9,7 @@ namespace IntelliTect.TestTools.Console
     public enum NormalizeOptions
     {
         /// <summary>
-        /// Whether VT100 color code characters should be ignored.
+        /// No normalization.
         /// </summary>
         None = 0,
         
@@ -19,8 +19,8 @@ namespace IntelliTect.TestTools.Console
         NormalizeLineEndings = 1,
         
         /// <summary>
-        /// No normalization
+        /// Whether ansi color code characters should be ignored.
         /// </summary>
-        StripVt100 = 2,
+        StripAnsiEscapeCodes = 2,
     }
 }

--- a/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework.Tests/IntelliTect.TestTools.TestFramework.Tests.csproj
+++ b/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework.Tests/IntelliTect.TestTools.TestFramework.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
- Add optional parameter to strip VT100 characters. This will ignore VT100 characters from input and expected output.