### PR TITLE
Add IntelliTect.TestTools.Data to make DB testing easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,6 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
+
+# Jetbrains
+.idea

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,24 +1,24 @@
 <Project>
-	<PropertyGroup>
-		<Company>IntelliTect</Company>
-		<Copyright>Copyright IntelliTect © 2020, All Rights Reserved.</Copyright>
-		<DefaultLanguage>en-US</DefaultLanguage>
-		<LangVersion>latest</LangVersion>
+    <PropertyGroup>
+        <Company>IntelliTect</Company>
+        <Copyright>Copyright IntelliTect © $([System.DateTime]::Now.ToString(`yyyy`)), All Rights Reserved.</Copyright>
+        <DefaultLanguage>en-US</DefaultLanguage>
+        <LangVersion>latest</LangVersion>
 
-		<VersionSuffix Condition=" '$(TESTTOOLS_VERSION_SUFFIX)' != '' ">$(TESTTOOLS_VERSION_SUFFIX)</VersionSuffix>
+        <VersionSuffix Condition=" '$(TESTTOOLS_VERSION_SUFFIX)' != '' ">$(TESTTOOLS_VERSION_SUFFIX)</VersionSuffix>
 
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningLevel>4</WarningLevel>
-			
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<PackageProjectUrl>https://github.com/IntelliTect/TestTools</PackageProjectUrl>
-		
-		<PublishRepositoryUrl>true</PublishRepositoryUrl>
-		<EmbedUntrackedSources>true</EmbedUntrackedSources>
-		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-	</PropertyGroup>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <WarningLevel>4</WarningLevel>
 
-	<ItemGroup Condition="$(IsPackable) == 'true'">
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-	</ItemGroup>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/IntelliTect/TestTools</PackageProjectUrl>
+
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    </PropertyGroup>
+
+    <ItemGroup Condition="$(IsPackable) == 'true'">
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    </ItemGroup>
 </Project>

--- a/IntelliTect.TestTools.Data.Test/BadDbContext.cs
+++ b/IntelliTect.TestTools.Data.Test/BadDbContext.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace IntelliTect.TestTools.Data.Test
+{
+    public class BadDbContext : DbContext
+    {
+        public DbSet<Person> Persons { get; set; }
+
+        public BadDbContext()
+        {
+        }
+    }
+}

--- a/IntelliTect.TestTools.Data.Test/BadDbContext.cs
+++ b/IntelliTect.TestTools.Data.Test/BadDbContext.cs
@@ -1,13 +1,19 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System;
+using Microsoft.EntityFrameworkCore;
 
 namespace IntelliTect.TestTools.Data.Test
 {
     public class BadDbContext : DbContext
     {
-        public DbSet<Person> Persons { get; set; }
+        private object MyDependency { get; }
 
         public BadDbContext()
         {
+        }
+
+        public BadDbContext(DbContextOptions options, object someOtherDependency) : base(options)
+        {
+            MyDependency = someOtherDependency ?? throw new ArgumentNullException(nameof(someOtherDependency));
         }
     }
 }

--- a/IntelliTect.TestTools.Data.Test/BlogPost.cs
+++ b/IntelliTect.TestTools.Data.Test/BlogPost.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace IntelliTect.TestTools.Data.Test
+{
+    public class BlogPost
+    {
+        public int BlogPostId { get; set; }
+
+        public DateTimeOffset DateCreated { get; set; }
+
+        public int NumberOfComments { get; set; }
+
+        public int PersonId { get; set; }
+
+        public Person Person { get; set; }
+    }
+}

--- a/IntelliTect.TestTools.Data.Test/DatabaseFixture.BadDbContext.Tests.cs
+++ b/IntelliTect.TestTools.Data.Test/DatabaseFixture.BadDbContext.Tests.cs
@@ -7,10 +7,13 @@ namespace IntelliTect.TestTools.Data.Test
     public class DatabaseFixtureBadDbContextTests
     {
         [Fact]
-        public void BadDbContext_MissingCorrectConstructor_ExceptionThrown()
+        public async Task BadDbContext_MissingCorrectConstructor_ExceptionThrown()
         {
             var databaseFixture = new DatabaseFixture<BadDbContext>();
-            databaseFixture.PerformDatabaseOperation(_ => Task.CompletedTask);
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await databaseFixture.PerformDatabaseOperation(_ => Task.CompletedTask);
+            });
         }
     }
 }

--- a/IntelliTect.TestTools.Data.Test/DatabaseFixture.BadDbContext.Tests.cs
+++ b/IntelliTect.TestTools.Data.Test/DatabaseFixture.BadDbContext.Tests.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace IntelliTect.TestTools.Data.Test
+{
+    public class DatabaseFixtureBadDbContextTests
+    {
+        [Fact]
+        public void BadDbContext_MissingCorrectConstructor_ExceptionThrown()
+        {
+            var databaseFixture = new DatabaseFixture<BadDbContext>();
+            databaseFixture.PerformDatabaseOperation(_ => Task.CompletedTask);
+        }
+    }
+}

--- a/IntelliTect.TestTools.Data.Test/DatabaseFixture.SampleDbContext.Tests.cs
+++ b/IntelliTect.TestTools.Data.Test/DatabaseFixture.SampleDbContext.Tests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using IntelliTect.IntelliTime.Data.Test.Util;
+using Xunit;
+
+namespace IntelliTect.TestTools.Data.Test
+{
+    public class DatabaseFixtureSampleDbContextTests : IClassFixture<DatabaseFixture<SampleDbContext>>
+    {
+        private readonly DatabaseFixture<SampleDbContext> _DatabaseFixture;
+
+        public DatabaseFixtureSampleDbContextTests(DatabaseFixture<SampleDbContext> databaseFixture)
+        {
+            _DatabaseFixture = databaseFixture ?? throw new ArgumentNullException(nameof(databaseFixture));
+        }
+
+        [Fact]
+        public void DatabaseFixture_CanPerformDatabaseOperation()
+        {
+            var person = FakesFactory.Create<Person>();
+
+            _DatabaseFixture.PerformDatabaseOperation(async context =>
+            {
+                await context.Persons.AddAsync(person);
+                await context.SaveChangesAsync();
+            });
+
+            _DatabaseFixture.PerformDatabaseOperation(context =>
+            {
+                var personInDatabase = context.Persons.SingleOrDefault();
+
+                Assert.NotNull(personInDatabase);
+                Assert.Equal(person.Age, personInDatabase.Age);
+                Assert.Equal(person.Name, personInDatabase.Name);
+
+                return Task.CompletedTask;
+            });
+        }
+
+        [Fact]
+        public void DatabaseFixture_EFInMemoryLoggingEnabled_LogsPopulated()
+        {
+            var person = FakesFactory.Create<Person>();
+
+            _DatabaseFixture.PerformDatabaseOperation(async context =>
+            {
+                await context.Persons.AddAsync(person);
+                await context.SaveChangesAsync();
+            });
+
+            var logger = _DatabaseFixture
+                .GetInMemoryLoggers()["Microsoft.EntityFrameworkCore.Database.Command"];
+
+            Assert.NotEmpty(logger.Logs);
+        }
+    }
+}

--- a/IntelliTect.TestTools.Data.Test/DatabaseFixture.SampleDbContext.Tests.cs
+++ b/IntelliTect.TestTools.Data.Test/DatabaseFixture.SampleDbContext.Tests.cs
@@ -55,6 +55,7 @@ namespace IntelliTect.TestTools.Data.Test
                 .GetInMemoryLoggers()["Microsoft.EntityFrameworkCore.Database.Command"];
 
             Assert.NotEmpty(logger.Logs);
+            Assert.NotEqual(0, logger.Logs.First().EventId);
         }
 
         [Fact]

--- a/IntelliTect.TestTools.Data.Test/DatabaseFixture.SampleDbContext.Tests.cs
+++ b/IntelliTect.TestTools.Data.Test/DatabaseFixture.SampleDbContext.Tests.cs
@@ -16,17 +16,17 @@ namespace IntelliTect.TestTools.Data.Test
         }
 
         [Fact]
-        public void DatabaseFixture_CanPerformDatabaseOperation()
+        public async Task DatabaseFixture_CanPerformDatabaseOperation()
         {
             var person = FakesFactory.Create<Person>();
 
-            _DatabaseFixture.PerformDatabaseOperation(async context =>
+            await _DatabaseFixture.PerformDatabaseOperation(async context =>
             {
                 await context.Persons.AddAsync(person);
                 await context.SaveChangesAsync();
             });
 
-            _DatabaseFixture.PerformDatabaseOperation(context =>
+            await _DatabaseFixture.PerformDatabaseOperation(context =>
             {
                 var personInDatabase = context.Persons.SingleOrDefault();
 
@@ -39,11 +39,11 @@ namespace IntelliTect.TestTools.Data.Test
         }
 
         [Fact]
-        public void DatabaseFixture_EFInMemoryLoggingEnabled_LogsPopulated()
+        public async Task DatabaseFixture_EFInMemoryLoggingEnabled_LogsPopulated()
         {
             var person = FakesFactory.Create<Person>();
 
-            _DatabaseFixture.PerformDatabaseOperation(async context =>
+            await _DatabaseFixture.PerformDatabaseOperation(async context =>
             {
                 await context.Persons.AddAsync(person);
                 await context.SaveChangesAsync();

--- a/IntelliTect.TestTools.Data.Test/DatabaseFixtureTests.cs
+++ b/IntelliTect.TestTools.Data.Test/DatabaseFixtureTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+using IntelliTect.IntelliTime.Data.Test.Util;
+using Xunit;
+
+namespace IntelliTect.TestTools.Data.Test
+{
+    public class DatabaseFixtureTests : IClassFixture<DatabaseFixture<SampleDbContext>>
+    {
+        private readonly DatabaseFixture<SampleDbContext> _DatabaseFixture;
+
+        public DatabaseFixtureTests(DatabaseFixture<SampleDbContext> databaseFixture)
+        {
+            _DatabaseFixture = databaseFixture ?? throw new ArgumentNullException(nameof(databaseFixture));
+        }
+
+        [Fact]
+        public void DatabaseFixture_CanPerformDatabaseOperation()
+        {
+            var person = FakesFactory.Create<Person>();
+
+            _DatabaseFixture.PerformDatabaseOperationAsync(async context =>
+            {
+                await context.Persons.AddAsync(person);
+                await context.SaveChangesAsync();
+            });
+
+            _DatabaseFixture.PerformDatabaseOperation(context =>
+            {
+                var personInDatabase = context.Persons.SingleOrDefault();
+
+                Assert.NotNull(personInDatabase);
+                Assert.Equal(person.Age, personInDatabase.Age);
+                Assert.Equal(person.Name, personInDatabase.Name);
+            });
+        }
+    }
+}

--- a/IntelliTect.TestTools.Data.Test/FakesFactory.cs
+++ b/IntelliTect.TestTools.Data.Test/FakesFactory.cs
@@ -42,7 +42,7 @@ namespace IntelliTect.IntelliTime.Data.Test.Util
         {
             Faker<T> faker = _AllFakers.OfType<Faker<T>>().FirstOrDefault();
 
-            if (faker == null)
+            if (faker is null)
             {
                 throw new InvalidOperationException(
                     $"Cannot construct and instance of type '{typeof(T).FullName}'");

--- a/IntelliTect.TestTools.Data.Test/FakesFactory.cs
+++ b/IntelliTect.TestTools.Data.Test/FakesFactory.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Bogus;
+using Person = IntelliTect.TestTools.Data.Test.Person;
+
+namespace IntelliTect.IntelliTime.Data.Test.Util
+{
+    public static class FakesFactory
+    {
+        private static readonly object[] _AllFakers;
+
+        private static readonly Faker<Person> _PersonFaker;
+
+        static FakesFactory()
+        {
+            _PersonFaker = new Faker<Person>()
+                .StrictMode(true)
+                .Ignore(x => x.PersonId)
+                .RuleFor(x => x.Age, f => f.Random.Int(1, 112))
+                .RuleFor(x => x.Name, f => f.Person.FirstName);
+
+            _AllFakers = typeof(FakesFactory).GetFields(BindingFlags.GetField
+                                                        | BindingFlags.Static
+                                                        | BindingFlags.NonPublic)
+                .Where(x => x.Name.ToLower().EndsWith("faker"))
+                .Select(field => field.GetValue(null))
+                .ToArray();
+        }
+
+        public static T Create<T>() where T : class
+        {
+            Faker<T> faker = _AllFakers.OfType<Faker<T>>().FirstOrDefault();
+
+            if (faker == null)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot construct and instance of type '{typeof(T).FullName}'");
+            }
+
+            return faker.Generate();
+        }
+    }
+}

--- a/IntelliTect.TestTools.Data.Test/FakesFactory.cs
+++ b/IntelliTect.TestTools.Data.Test/FakesFactory.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Reflection;
 using Bogus;
+using IntelliTect.TestTools.Data.Test;
 using Person = IntelliTect.TestTools.Data.Test.Person;
 
 namespace IntelliTect.IntelliTime.Data.Test.Util
@@ -11,14 +12,23 @@ namespace IntelliTect.IntelliTime.Data.Test.Util
         private static readonly object[] _AllFakers;
 
         private static readonly Faker<Person> _PersonFaker;
+        private static readonly Faker<BlogPost> _BlogPostFaker;
 
         static FakesFactory()
         {
             _PersonFaker = new Faker<Person>()
                 .StrictMode(true)
                 .Ignore(x => x.PersonId)
+                .Ignore(x => x.BlogPosts)
                 .RuleFor(x => x.Age, f => f.Random.Int(1, 112))
                 .RuleFor(x => x.Name, f => f.Person.FirstName);
+
+            _BlogPostFaker = new Faker<BlogPost>()
+                .StrictMode(false)
+                .Ignore(x => x.BlogPostId)
+                .Ignore(x => x.PersonId)
+                .RuleFor(x => x.DateCreated, DateTimeOffset.Now)
+                .RuleFor(x => x.NumberOfComments, f => f.Random.Int(0, 100));
 
             _AllFakers = typeof(FakesFactory).GetFields(BindingFlags.GetField
                                                         | BindingFlags.Static

--- a/IntelliTect.TestTools.Data.Test/IntelliTect.TestTools.Data.Test.csproj
+++ b/IntelliTect.TestTools.Data.Test/IntelliTect.TestTools.Data.Test.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Bogus" Version="29.0.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="xunit" Version="2.4.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\IntelliTect.TestTools.Data\IntelliTect.TestTools.Data.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/IntelliTect.TestTools.Data.Test/Person.cs
+++ b/IntelliTect.TestTools.Data.Test/Person.cs
@@ -1,0 +1,11 @@
+﻿namespace IntelliTect.TestTools.Data.Test
+{
+    public class Person
+    {
+        public int PersonId { get; set; }
+
+        public string Name { get; set; }
+
+        public int Age { get; set; }
+    }
+}

--- a/IntelliTect.TestTools.Data.Test/Person.cs
+++ b/IntelliTect.TestTools.Data.Test/Person.cs
@@ -1,4 +1,6 @@
-﻿namespace IntelliTect.TestTools.Data.Test
+﻿using System.Collections.Generic;
+
+namespace IntelliTect.TestTools.Data.Test
 {
     public class Person
     {
@@ -7,5 +9,7 @@
         public string Name { get; set; }
 
         public int Age { get; set; }
+
+        public ICollection<BlogPost> BlogPosts { get; set; }
     }
 }

--- a/IntelliTect.TestTools.Data.Test/SampleDbContext.cs
+++ b/IntelliTect.TestTools.Data.Test/SampleDbContext.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace IntelliTect.TestTools.Data.Test
+{
+    public class SampleDbContext : DbContext
+    {
+        public DbSet<Person> Persons { get; set; }
+
+        public SampleDbContext(DbContextOptions options) : base(options)
+        {
+        }
+
+        public SampleDbContext(DbContextOptions options, string something) : base(options)
+        {
+        }
+    }
+}

--- a/IntelliTect.TestTools.Data.Test/SampleDbContext.cs
+++ b/IntelliTect.TestTools.Data.Test/SampleDbContext.cs
@@ -6,6 +6,8 @@ namespace IntelliTect.TestTools.Data.Test
     {
         public DbSet<Person> Persons { get; set; }
 
+        public DbSet<BlogPost> BlogPosts { get; set; }
+
         public SampleDbContext(DbContextOptions options) : base(options)
         {
         }

--- a/IntelliTect.TestTools.Data.sln
+++ b/IntelliTect.TestTools.Data.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntelliTect.TestTools.Data", "IntelliTect.TestTools.Data\IntelliTect.TestTools.Data.csproj", "{689C10E8-4735-43B0-8A29-77845E549E3F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntelliTect.TestTools.Data.Test", "IntelliTect.TestTools.Data.Test\IntelliTect.TestTools.Data.Test.csproj", "{62094069-2820-49DA-9A0E-4FB39883CA84}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{689C10E8-4735-43B0-8A29-77845E549E3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{689C10E8-4735-43B0-8A29-77845E549E3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{689C10E8-4735-43B0-8A29-77845E549E3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{689C10E8-4735-43B0-8A29-77845E549E3F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62094069-2820-49DA-9A0E-4FB39883CA84}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62094069-2820-49DA-9A0E-4FB39883CA84}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62094069-2820-49DA-9A0E-4FB39883CA84}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{62094069-2820-49DA-9A0E-4FB39883CA84}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/IntelliTect.TestTools.Data/DatabaseFixture.cs
+++ b/IntelliTect.TestTools.Data/DatabaseFixture.cs
@@ -82,8 +82,10 @@ namespace IntelliTect.TestTools.Data
 
         /// <summary>
         /// Creates new instance of TDBContext and executes database operation.
-        /// This avoids issues where reusing the same DbContext can result in cached objects being returning,
-        /// suppressing problems.
+        /// This avoids issues where reusing the same DbContext can result in cached objects being returned,
+        /// suppressing issues with your LINQ to SQL code.
+        /// At minimum the Arrange/Act/Assert portions should each invoke this method separately, but more invocations
+        /// of this method should be preferred whenever possible.
         /// </summary>
         /// <param name="operation">The database operation to be performed</param>
         public async Task PerformDatabaseOperation(Func<TDbContext, Task> operation)

--- a/IntelliTect.TestTools.Data/DatabaseFixture.cs
+++ b/IntelliTect.TestTools.Data/DatabaseFixture.cs
@@ -29,6 +29,9 @@ namespace IntelliTect.TestTools.Data
                 .Options);
         }
 
+        /// <summary>
+        /// Fired when loggers are being setup. Immediately follows adding the InMemoryLogger
+        /// </summary>
         public event EventHandler<ILoggingBuilder>? BeforeLoggingSetup;
 
         private ILoggerFactory GetLoggerFactory()
@@ -77,12 +80,25 @@ namespace IntelliTect.TestTools.Data
             return db;
         }
 
+        /// <summary>
+        /// Creates new instance of TDBContext and executes database operation.
+        /// This avoids issues where reusing the same DbContext can result in cached objects being returning,
+        /// suppressing problems.
+        /// </summary>
+        /// <param name="operation">The database operation to be performed</param>
         public async Task PerformDatabaseOperation(Func<TDbContext, Task> operation)
         {
             var db = CreateNewContext();
             await operation(db);
         }
 
+        /// <summary>
+        /// If <see cref="InMemoryLogger"/> is configured and DbContext has been accessed at least once, returns a
+        /// Dictionary of all InMemoryLoggers
+        /// </summary>
+        /// <returns>Dictionary with category name, and instance of all InMemoryLoggers</returns>
+        /// <exception cref="InvalidOperationException">InMemoryLogger is not configured, or DbContext has not yet
+        /// been accessed</exception>
         public ConcurrentDictionary<string,InMemoryLogger> GetInMemoryLoggers()
         {
             if (ServiceProvider is null)

--- a/IntelliTect.TestTools.Data/DatabaseFixture.cs
+++ b/IntelliTect.TestTools.Data/DatabaseFixture.cs
@@ -15,7 +15,7 @@ namespace IntelliTect.TestTools.Data
 
         private Lazy<DbContextOptions<TDbContext>> Options { get; }
 
-        private IServiceProvider ServiceProvider { get; set; }
+        private IServiceProvider? ServiceProvider { get; set; }
 
         public DatabaseFixture()
         {
@@ -29,7 +29,7 @@ namespace IntelliTect.TestTools.Data
                 .Options);
         }
 
-        public event EventHandler<ILoggingBuilder> BeforeLoggingSetup;
+        public event EventHandler<ILoggingBuilder>? BeforeLoggingSetup;
 
         private ILoggerFactory GetLoggerFactory()
         {

--- a/IntelliTect.TestTools.Data/DatabaseFixture.cs
+++ b/IntelliTect.TestTools.Data/DatabaseFixture.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace IntelliTect.TestTools.Data
+{
+    public class DatabaseFixture<T> where T : DbContext
+    {
+        private SqliteConnection SqliteConnection { get; }
+        private DbContextOptions<T> Options { get; }
+
+        public DatabaseFixture()
+        {
+            SqliteConnection = new SqliteConnection("DataSource=:memory:");
+            SqliteConnection.Open();
+
+            Options = new DbContextOptionsBuilder<T>()
+                .UseSqlite(SqliteConnection)
+                .Options;
+
+            using var db = CreateNewContext();
+            db.Database.EnsureCreated();
+        }
+
+        private T CreateNewContext()
+        {
+            var constructor = typeof(T)
+                .GetConstructors()
+                .Select(x => x.GetParameters())
+                .Where(x => x.Length == 1)
+                .Select(x => x.SingleOrDefault())
+                .Where(x => x != null)
+                .SingleOrDefault(x => x.ParameterType == typeof(DbContextOptions));
+
+            if (constructor is null)
+            {
+                throw new InvalidOperationException(
+                    $"'{typeof(T)}' must contain a constructor that has a single parameter " +
+                    "of type 'DbContextOptions'");
+            }
+
+            var db = Activator.CreateInstance(typeof(T), Options);
+
+            if (db is null)
+            {
+                throw new InvalidOperationException($"'{typeof(T)} could not be instantiated");
+            }
+
+            return (T) db;
+        }
+
+        public async Task PerformDatabaseOperationAsync(Func<T, Task> operation)
+        {
+            var db = CreateNewContext();
+            await operation(db);
+        }
+
+        public void PerformDatabaseOperation(Action<T> operation)
+        {
+            var db = CreateNewContext();
+            operation(db);
+        }
+    }
+}

--- a/IntelliTect.TestTools.Data/DatabaseFixture.cs
+++ b/IntelliTect.TestTools.Data/DatabaseFixture.cs
@@ -111,8 +111,8 @@ namespace IntelliTect.TestTools.Data
 
             if (!(ServiceProvider.GetService<ILoggerProvider>() is InMemoryLoggerProvider loggerProvider))
             {
-                throw new InvalidOperationException($"{typeof(ILoggerProvider)} of type " +
-                                                    $"{typeof(InMemoryLoggerProvider)} could not be found.");
+                throw new InvalidOperationException($"{typeof(ILoggerProvider).FullName} of type " +
+                                                    $"{typeof(InMemoryLoggerProvider).FullName} could not be found.");
             }
 
             return loggerProvider.GetLoggers();

--- a/IntelliTect.TestTools.Data/ILoggingBuilderMixins.cs
+++ b/IntelliTect.TestTools.Data/ILoggingBuilderMixins.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+
+namespace IntelliTect.TestTools.Data
+{
+    public static class ILoggingBuilderMixins
+    {
+        public static ILoggingBuilder AddInMemory(this ILoggingBuilder builder)
+        {
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, InMemoryLoggerProvider>());
+            return builder;
+        }
+    }
+}

--- a/IntelliTect.TestTools.Data/ILoggingBuilderMixins.cs
+++ b/IntelliTect.TestTools.Data/ILoggingBuilderMixins.cs
@@ -6,6 +6,11 @@ namespace IntelliTect.TestTools.Data
 {
     public static class ILoggingBuilderMixins
     {
+        /// <summary>
+        /// Adds the <see cref="InMemoryLoggerProvider"/> to the factory.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/>to use.</param>
+        /// <returns><see cref="ILoggingBuilder"/> with <see cref="InMemoryLoggerProvider"/> configured.</returns>
         public static ILoggingBuilder AddInMemory(this ILoggingBuilder builder)
         {
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, InMemoryLoggerProvider>());

--- a/IntelliTect.TestTools.Data/InMemoryLogger.cs
+++ b/IntelliTect.TestTools.Data/InMemoryLogger.cs
@@ -6,8 +6,20 @@ namespace IntelliTect.TestTools.Data
 {
     public class InMemoryLogger : ILogger
     {
+        /// <summary>
+        /// Collection of all Logs recorded by this InMemoryLogger
+        /// </summary>
         public List<Log> Logs { get; } = new List<Log>();
 
+        /// <summary>
+        /// Writes a log entry.
+        /// </summary>
+        /// <param name="logLevel">Entry will be written on this level.</param>
+        /// <param name="eventId">Id of the event.</param>
+        /// <param name="state">The entry to be written. Can be also an object.</param>
+        /// <param name="exception">The exception related to this entry.</param>
+        /// <param name="formatter">Function to create a <see cref="T:System.String" /> message of the <paramref name="state" /> and <paramref name="exception" />.</param>
+        /// <typeparam name="TState">The type of the object to be written.</typeparam>
         public void Log<TState>(
             LogLevel logLevel,
             EventId eventId,
@@ -18,11 +30,17 @@ namespace IntelliTect.TestTools.Data
             Logs.Add(new Log(logLevel, eventId, state, exception));
         }
 
+        /// <summary>
+        /// InMemoryLogger cannot be disabled. Once created an InMemoryLogger will always return true for enabled.
+        /// </summary>
         public bool IsEnabled(LogLevel logLevel)
         {
             return true;
         }
 
+        /// <summary>
+        /// Not Implemented
+        /// </summary>
         public IDisposable BeginScope<TState>(TState state)
         {
             throw new NotImplementedException();

--- a/IntelliTect.TestTools.Data/InMemoryLogger.cs
+++ b/IntelliTect.TestTools.Data/InMemoryLogger.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace IntelliTect.TestTools.Data
+{
+    public class InMemoryLogger : ILogger
+    {
+        public List<Log> Logs { get; } = new List<Log>();
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception exception,
+            Func<TState, Exception, string> formatter)
+        {
+            Logs.Add(new Log(logLevel, eventId, state, exception));
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/IntelliTect.TestTools.Data/InMemoryLoggerProvider.cs
+++ b/IntelliTect.TestTools.Data/InMemoryLoggerProvider.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace IntelliTect.TestTools.Data
+{
+    public class InMemoryLoggerProvider : ILoggerProvider
+    {
+        private readonly ConcurrentDictionary<string, InMemoryLogger> _Loggers
+            = new ConcurrentDictionary<string, InMemoryLogger>();
+
+        public void Dispose()
+        {
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return _Loggers.GetOrAdd(categoryName, s => new InMemoryLogger());
+        }
+
+        public ConcurrentDictionary<string, InMemoryLogger> GetLoggers()
+        {
+            return _Loggers;
+        }
+    }
+}

--- a/IntelliTect.TestTools.Data/InMemoryLoggerProvider.cs
+++ b/IntelliTect.TestTools.Data/InMemoryLoggerProvider.cs
@@ -12,11 +12,21 @@ namespace IntelliTect.TestTools.Data
         {
         }
 
+        /// <summary>
+        /// Creates a new <see cref="InMemoryLogger" /> instance.
+        /// </summary>
+        /// <param name="categoryName">The category name for messages produced by the logger.</param>
+        /// <returns>The instance of <see cref="InMemoryLogger" /> that was created.</returns>
         public ILogger CreateLogger(string categoryName)
         {
             return _Loggers.GetOrAdd(categoryName, s => new InMemoryLogger());
         }
 
+        /// <summary>
+        /// Provides a ConcurrentDictionary of category names with associated <see cref="InMemoryLogger"/> instance.
+        /// </summary>
+        /// <returns>ConcurrentDictionary of logger category name with associated
+        /// <see cref="InMemoryLogger"/> instance</returns>
         public ConcurrentDictionary<string, InMemoryLogger> GetLoggers()
         {
             return _Loggers;

--- a/IntelliTect.TestTools.Data/IntelliTect.TestTools.Data.csproj
+++ b/IntelliTect.TestTools.Data/IntelliTect.TestTools.Data.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.4" />
+    </ItemGroup>
+
+</Project>

--- a/IntelliTect.TestTools.Data/IntelliTect.TestTools.Data.csproj
+++ b/IntelliTect.TestTools.Data/IntelliTect.TestTools.Data.csproj
@@ -6,6 +6,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.4" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.4" />
     </ItemGroup>
 
 </Project>

--- a/IntelliTect.TestTools.Data/IntelliTect.TestTools.Data.csproj
+++ b/IntelliTect.TestTools.Data/IntelliTect.TestTools.Data.csproj
@@ -2,6 +2,8 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
+        <LangVersion>8.0</LangVersion>
+        <Nullable>Enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/IntelliTect.TestTools.Data/Log.cs
+++ b/IntelliTect.TestTools.Data/Log.cs
@@ -7,13 +7,13 @@ namespace IntelliTect.TestTools.Data
     {
         public LogLevel LogLevel { get; }
         public EventId EventId { get; }
-        public object State { get; }
+        public object? State { get; }
         public Exception Exception { get; }
 
         public Log(
             LogLevel logLevel,
             EventId eventId,
-            object state,
+            object? state,
             Exception exception)
         {
             LogLevel = logLevel;

--- a/IntelliTect.TestTools.Data/Log.cs
+++ b/IntelliTect.TestTools.Data/Log.cs
@@ -5,11 +5,33 @@ namespace IntelliTect.TestTools.Data
 {
     public class Log
     {
+        /// <summary>
+        /// Level of log entry.
+        /// </summary>
         public LogLevel LogLevel { get; }
-        public EventId EventId { get; }
-        public object? State { get; }
-        public Exception Exception { get; }
 
+        /// <summary>
+        /// Id of the event.
+        /// </summary>
+        public EventId EventId { get; }
+
+        /// <summary>
+        /// Log entry contents.
+        /// </summary>
+        public object? State { get; }
+
+        /// <summary>
+        /// The exception for the entry.
+        /// </summary>
+        public Exception? Exception { get; }
+
+        /// <summary>
+        /// Represents a single log event.
+        /// </summary>
+        /// <param name="logLevel">Entry will be written on this level.</param>
+        /// <param name="eventId">Id of the event.</param>
+        /// <param name="state">The entry to be written. Can be also an object.</param>
+        /// <param name="exception">The exception related to this entry.</param>
         public Log(
             LogLevel logLevel,
             EventId eventId,

--- a/IntelliTect.TestTools.Data/Log.cs
+++ b/IntelliTect.TestTools.Data/Log.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+
+namespace IntelliTect.TestTools.Data
+{
+    public class Log
+    {
+        private readonly LogLevel _LogLevel;
+        private readonly EventId _EventId;
+        private readonly object _State;
+        private readonly Exception _Exception;
+
+        public Log(
+            LogLevel logLevel,
+            EventId eventId,
+            object state,
+            Exception exception)
+        {
+            _LogLevel = logLevel;
+            _EventId = eventId;
+            _State = state;
+            _Exception = exception;
+        }
+    }
+}

--- a/IntelliTect.TestTools.Data/Log.cs
+++ b/IntelliTect.TestTools.Data/Log.cs
@@ -5,10 +5,10 @@ namespace IntelliTect.TestTools.Data
 {
     public class Log
     {
-        private readonly LogLevel _LogLevel;
-        private readonly EventId _EventId;
-        private readonly object _State;
-        private readonly Exception _Exception;
+        public LogLevel LogLevel { get; }
+        public EventId EventId { get; }
+        public object State { get; }
+        public Exception Exception { get; }
 
         public Log(
             LogLevel logLevel,
@@ -16,10 +16,10 @@ namespace IntelliTect.TestTools.Data
             object state,
             Exception exception)
         {
-            _LogLevel = logLevel;
-            _EventId = eventId;
-            _State = state;
-            _Exception = exception;
+            LogLevel = logLevel;
+            EventId = eventId;
+            State = state;
+            Exception = exception;
         }
     }
 }


### PR DESCRIPTION
- Add DbFixture that takes DbContext and setups up in memory Database Connections
- Restrict Database access to Func, to ensure that invokers access new DbContext to avoid caching 