### PR TITLE
Use constructor DbContextOptions of DbContext type rather than generic

### DIFF
--- a/IntelliTect.TestTools.Data.Test/SampleDbContext.cs
+++ b/IntelliTect.TestTools.Data.Test/SampleDbContext.cs
@@ -8,7 +8,7 @@ namespace IntelliTect.TestTools.Data.Test
 
         public DbSet<BlogPost> BlogPosts { get; set; }
 
-        public SampleDbContext(DbContextOptions options) : base(options)
+        public SampleDbContext(DbContextOptions<SampleDbContext> options) : base(options)
         {
         }
 

--- a/IntelliTect.TestTools.Data/DatabaseFixture.cs
+++ b/IntelliTect.TestTools.Data/DatabaseFixture.cs
@@ -57,7 +57,9 @@ namespace IntelliTect.TestTools.Data
                 .Where(x =>
                 {
                     var parameters = x.GetParameters();
-                    return parameters.Length == 1 && parameters[0].ParameterType == typeof(DbContextOptions);
+                    return parameters.Length == 1
+                           && parameters[0].ParameterType == typeof(DbContextOptions<>)
+                               .MakeGenericType(typeof(TDbContext));
                 })
                 .SingleOrDefault();
 


### PR DESCRIPTION
This is a breaking change to V0.1.0, but this is what the AppDbContext constructor should look like, and this is how it should have originally been implemented.