### PR TITLE
Fixes a Regex that was overly aggressive

### DIFF
--- a/IntelliTect.TestTools.Console.Tests/ConsoleAssertTests.cs
+++ b/IntelliTect.TestTools.Console.Tests/ConsoleAssertTests.cs
@@ -121,22 +121,17 @@ End";
         }
 
         [TestMethod]
-        public void ConsoleTester_OutputIncludesPluses_PlusesAreNotStripped()
+        [DataRow("C++")]
+        [DataRow("word + word")]
+        [DataRow("+hello+world+")]
+        public void ConsoleTester_OutputIncludesPluses_PlusesAreNotStripped(string consoleInput)
         {
-            List<string> consoleInputCases = new List<string> {
-                "C++",
-                "word + word",
-                "+hello+world+"
-            };
-
-            foreach (string consoleInput in consoleInputCases) {
-                Exception exception = Assert.ThrowsException<Exception>(() => {
-                    ConsoleAssert.Expect(consoleInput, () => {
-                        System.Console.Write(""); // Always fail
-                    }, NormalizeOptions.None);
-                });
-                StringAssert.Contains(exception.Message, consoleInput);
-            }
+            Exception exception = Assert.ThrowsException<Exception>(() => {
+                ConsoleAssert.Expect(consoleInput, () => {
+                    System.Console.Write(""); // Always fail
+                }, NormalizeOptions.None);
+            });
+            StringAssert.Contains(exception.Message, consoleInput);
         }
 
         [TestMethod]

--- a/IntelliTect.TestTools.Console.Tests/ConsoleAssertTests.cs
+++ b/IntelliTect.TestTools.Console.Tests/ConsoleAssertTests.cs
@@ -120,6 +120,21 @@ End";
         }
 
         [TestMethod]
+        public void ConsoleTester_DoesNotStripPluses()
+        {
+            String assert_expect = "C++";
+            String assert_actual = "Not C++";
+
+            Exception exception = Assert.ThrowsException<Exception>(() => {
+                ConsoleAssert.Expect(assert_expect, () => {
+                    System.Console.Write(assert_actual);
+                }, NormalizeOptions.None);
+            });
+            StringAssert.Contains(exception.Message, assert_expect);
+            StringAssert.Contains(exception.Message, assert_actual);
+        }
+
+        [TestMethod]
         public void ConsoleTester_HelloWorld_MissingNewline()
         {
             const string view = @"Hello World

--- a/IntelliTect.TestTools.Console.Tests/ConsoleAssertTests.cs
+++ b/IntelliTect.TestTools.Console.Tests/ConsoleAssertTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using IntelliTect.TestTools.Console;
@@ -120,18 +121,22 @@ End";
         }
 
         [TestMethod]
-        public void ConsoleTester_DoesNotStripPluses()
+        public void ConsoleTester_OutputIncludesPluses_PlusesAreNotStripped()
         {
-            String assert_expect = "C++";
-            String assert_actual = "Not C++";
+            List<string> consoleInputCases = new List<string> {
+                "C++",
+                "word + word",
+                "+hello+world+"
+            };
 
-            Exception exception = Assert.ThrowsException<Exception>(() => {
-                ConsoleAssert.Expect(assert_expect, () => {
-                    System.Console.Write(assert_actual);
-                }, NormalizeOptions.None);
-            });
-            StringAssert.Contains(exception.Message, assert_expect);
-            StringAssert.Contains(exception.Message, assert_actual);
+            foreach (string consoleInput in consoleInputCases) {
+                Exception exception = Assert.ThrowsException<Exception>(() => {
+                    ConsoleAssert.Expect(consoleInput, () => {
+                        System.Console.Write(""); // Always fail
+                    }, NormalizeOptions.None);
+                });
+                StringAssert.Contains(exception.Message, consoleInput);
+            }
         }
 
         [TestMethod]

--- a/IntelliTect.TestTools.Console/ConsoleAssert.cs
+++ b/IntelliTect.TestTools.Console/ConsoleAssert.cs
@@ -449,7 +449,7 @@ namespace IntelliTect.TestTools.Console
                     new CodeGeneratorOptions() { BlankLinesBetweenMembers = false });
                 result = writer.ToString();
 
-		        // Remove extra text added during formatting (..realtext" + "realtext..)
+                // Remove extra text added during formatting (..realtext" + "realtext..)
                 return Regex.Replace(result, @"""\s+\+\s+""", "");
             }
         }

--- a/IntelliTect.TestTools.Console/ConsoleAssert.cs
+++ b/IntelliTect.TestTools.Console/ConsoleAssert.cs
@@ -448,7 +448,7 @@ namespace IntelliTect.TestTools.Console
                 provider.GenerateCodeFromExpression(new CodePrimitiveExpression(text), writer, 
                     new CodeGeneratorOptions() { BlankLinesBetweenMembers = false });
                 result = writer.ToString();
-		
+
 		// Remove extra text added during formatting (..realtext" + "realtext..)
                 return Regex.Replace(result, @"""\s+\+\s+""", "");
 

--- a/IntelliTect.TestTools.Console/ConsoleAssert.cs
+++ b/IntelliTect.TestTools.Console/ConsoleAssert.cs
@@ -448,8 +448,10 @@ namespace IntelliTect.TestTools.Console
                 provider.GenerateCodeFromExpression(new CodePrimitiveExpression(text), writer, 
                     new CodeGeneratorOptions() { BlankLinesBetweenMembers = false });
                 result = writer.ToString();
-                // Remove extra lines added during code generation (Note: BlankLinesBetweenMembers = false does not suffice)
-                return Regex.Replace(result, @"\s*\+\s*", "");
+		
+		// Remove extra text added during formatting (..realtext" + "realtext..)
+                return Regex.Replace(result, @"""\s+\+\s+""", "");
+
             }
         }
 

--- a/IntelliTect.TestTools.Console/ConsoleAssert.cs
+++ b/IntelliTect.TestTools.Console/ConsoleAssert.cs
@@ -559,4 +559,4 @@ namespace IntelliTect.TestTools.Console
             return process;
         }
     }
-
+}

--- a/IntelliTect.TestTools.Console/ConsoleAssert.cs
+++ b/IntelliTect.TestTools.Console/ConsoleAssert.cs
@@ -451,7 +451,6 @@ namespace IntelliTect.TestTools.Console
 
 		// Remove extra text added during formatting (..realtext" + "realtext..)
                 return Regex.Replace(result, @"""\s+\+\s+""", "");
-
             }
         }
 
@@ -560,4 +559,4 @@ namespace IntelliTect.TestTools.Console
             return process;
         }
     }
-}
+

--- a/IntelliTect.TestTools.Console/ConsoleAssert.cs
+++ b/IntelliTect.TestTools.Console/ConsoleAssert.cs
@@ -449,7 +449,7 @@ namespace IntelliTect.TestTools.Console
                     new CodeGeneratorOptions() { BlankLinesBetweenMembers = false });
                 result = writer.ToString();
 
-		// Remove extra text added during formatting (..realtext" + "realtext..)
+		        // Remove extra text added during formatting (..realtext" + "realtext..)
                 return Regex.Replace(result, @"""\s+\+\s+""", "");
             }
         }


### PR DESCRIPTION
This improves a Regex that incorrectly removed "+" characters when it wasn't necessary.
This also fixes an issue where " characters would be incorrectly inserted into formatted output when the printed strings were very long.

Closes #59 
