### PR TITLE
Using system.text.json instead of newtonsoft

### DIFF
--- a/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate.csproj
+++ b/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate.csproj
@@ -17,7 +17,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IntelliTect.Analyzers" Version="0.1.7" />
+    <PackageReference Include="IntelliTect.Analyzers" Version="0.1.8">
+      <ExcludeAssets>all</ExcludeAssets>
+    </PackageReference>
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
   </ItemGroup>
 

--- a/IntelliTect.TestTools.TestFramework/ExampleTests/ExampleTests/ExampleTests.csproj
+++ b/IntelliTect.TestTools.TestFramework/ExampleTests/ExampleTests/ExampleTests.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="IntelliTect.TestTools.TestFramework" Version="1.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Selenium.WebDriver" Version="4.0.0-alpha01" />
+    <PackageReference Include="System.Text.Json" Version="4.7.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/IntelliTect.TestTools.TestFramework/ExampleTests/ExampleTests/Harness/BasePage.cs
+++ b/IntelliTect.TestTools.TestFramework/ExampleTests/ExampleTests/Harness/BasePage.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 using OpenQA.Selenium;
 
 namespace ExampleTests.Harness

--- a/IntelliTect.TestTools.TestFramework/ExampleTests/ExampleTests/Harness/IntelliTectWebpage.cs
+++ b/IntelliTect.TestTools.TestFramework/ExampleTests/ExampleTests/Harness/IntelliTectWebpage.cs
@@ -1,5 +1,5 @@
-﻿using Newtonsoft.Json;
-using OpenQA.Selenium;
+﻿using OpenQA.Selenium;
+using System.Text.Json.Serialization;
 
 namespace ExampleTests.Harness
 {

--- a/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework.csproj
+++ b/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework.csproj
@@ -8,7 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IntelliTect.Analyzers" Version="0.1.7" />
+    <PackageReference Include="IntelliTect.Analyzers" Version="0.1.8">
+      <ExcludeAssets>all</ExcludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />

--- a/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework.csproj
+++ b/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 
 </Project>

--- a/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework/TestBuilder.cs
+++ b/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework/TestBuilder.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json;
+using System.Text.Json;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -196,14 +196,7 @@ namespace IntelliTect.TestTools.TestFramework
 
         private static string GetObjectDataAsJsonString(object obj)
         {
-            try
-            {
-                return JsonConvert.SerializeObject(obj, Formatting.Indented, new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Objects });
-            }
-            catch (JsonSerializationException e)
-            {
-                return $"Unable to serialize to JSON. Mark the relevant property or constructor with the [JsonIgnore] attribute: {e.Message}";
-            }
+            return JsonSerializer.Serialize(obj, new JsonSerializerOptions { WriteIndented = true });
         }
 
         private object GetTestBlock(IServiceScope scope, Type tbType)

--- a/testframework-pipeline.yml
+++ b/testframework-pipeline.yml
@@ -13,7 +13,7 @@ variables:
   solution: '**/IntelliTect.TestTools.TestFramework.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
-  version: '1.1.2'
+  version: '1.1.3'
 
 steps:
 - task: NuGetToolInstaller@0


### PR DESCRIPTION
This PR takes a stab at issue #62 
As far as i can tell, the json conversion is only used for logging purposes. there will be some differences in the output and serialization behavior. See [migration documentation](https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to) for a detailed overview.

Example shortcomings of this solution:
- Polymorphic serialization of properties does not work as it did with Newtonsoft. 
- There is no substitute for the TypeNameHandling option. We could write a custom serializer and add the TypeName as a separate Field.