### PR TITLE
Private analyzers

### DIFF
--- a/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate.csproj
+++ b/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate/IntelliTect.TestTools.Selenate.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="IntelliTect.Analyzers" Version="0.1.8">
-      <ExcludeAssets>all</ExcludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
   </ItemGroup>

--- a/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework.csproj
+++ b/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="IntelliTect.Analyzers" Version="0.1.8">
-      <ExcludeAssets>all</ExcludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />


### PR DESCRIPTION
I accidentally set analyzers to exclude, which still passes them onto the consuming project. Changing to private.