### PR TITLE
Additional AddService and AddInstance methods

### DIFF
--- a/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework.Tests/ExampleDataThing.cs
+++ b/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework.Tests/ExampleDataThing.cs
@@ -1,6 +1,11 @@
 ﻿namespace IntelliTect.TestTools.TestFramework.Tests
 {
-    public class ExampleDataThing
+    public interface IExampleDataInterface
+    {
+        string Testing { get; set; }
+    }
+
+    public class ExampleDataThing : IExampleDataInterface
     {
         public string Testing { get; set; } = "Testing";
     }

--- a/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework.Tests/TestBuilderTests.cs
+++ b/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework.Tests/TestBuilderTests.cs
@@ -105,6 +105,26 @@ namespace IntelliTect.TestTools.TestFramework.Tests
                 .ExecuteTestCase();
         }
 
+        [Fact]
+        public void FetchByImplementationForExecuteArg()
+        {
+            TestBuilder builder = new TestBuilder();
+            builder
+                .AddDependencyInstance<IExampleDataInterface>(new ExampleDataThing())
+                .AddTestBlock<ExampleTestBlockWithExecuteArgForInterface>()
+                .ExecuteTestCase();
+        }
+
+        [Fact]
+        public void FetchByImplementationAndTypeForExecuteArg()
+        {
+            TestBuilder builder = new TestBuilder();
+            builder
+                .AddDependencyService<IExampleDataInterface, ExampleDataThing>()
+                .AddTestBlock<ExampleTestBlockWithExecuteArgForInterface>()
+                .ExecuteTestCase();
+        }
+
         // This test probably isn't necessary. This is MS DI out-of-the-box functionality
         [Fact]
         public void FetchByFactoryForConstructor()
@@ -369,6 +389,15 @@ namespace IntelliTect.TestTools.TestFramework.Tests
     public class ExampleTestBlockWithExecuteArgForOwnType : ITestBlock
     {
         public void Execute(ExampleDataThing input)
+        {
+            if (input == null) throw new ArgumentNullException(nameof(input));
+            Assert.Equal("Testing", input.Testing);
+        }
+    }
+
+    public class ExampleTestBlockWithExecuteArgForInterface : ITestBlock
+    {
+        public void Execute(IExampleDataInterface input)
         {
             if (input == null) throw new ArgumentNullException(nameof(input));
             Assert.Equal("Testing", input.Testing);

--- a/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework.csproj
+++ b/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="IntelliTect.Analyzers" Version="0.1.8">
-      <ExcludeAssets>all</ExcludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />

--- a/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework/TestBuilder.cs
+++ b/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework/TestBuilder.cs
@@ -79,9 +79,9 @@ namespace IntelliTect.TestTools.TestFramework
             return this;
         }
 
-        public TestBuilder AddDependencyService<TService,TImplementation>()
+        public TestBuilder AddDependencyService<TServiceType,TImplementationType>()
         {
-            Services.AddScoped(typeof(TService), typeof(TImplementation));
+            Services.AddScoped(typeof(TServiceType), typeof(TImplementationType));
             return this;
         }
 

--- a/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework/TestBuilder.cs
+++ b/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework/TestBuilder.cs
@@ -79,6 +79,12 @@ namespace IntelliTect.TestTools.TestFramework
             return this;
         }
 
+        public TestBuilder AddDependencyService<TService,TImplementation>()
+        {
+            Services.AddScoped(typeof(TService), typeof(TImplementation));
+            return this;
+        }
+
         /// <summary>
         /// Adds an instance of a Type to the container that is needed for a TestBlock to execute
         /// </summary>

--- a/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework/TestBuilder.cs
+++ b/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework/TestBuilder.cs
@@ -92,6 +92,12 @@ namespace IntelliTect.TestTools.TestFramework
             return this;
         }
 
+        public TestBuilder AddDependencyInstance<T>(object objToAdd)
+        {
+            Services.AddSingleton(typeof(T), objToAdd);
+            return this;
+        }
+
         // Are there other cases where we'll need to add something at this level?
         // If so, this shouldn't be called "AddLogger".
         // Might need to make this scoped. It's behaving oddly when running tests in parallel

--- a/testframework-pipeline.yml
+++ b/testframework-pipeline.yml
@@ -13,7 +13,7 @@ variables:
   solution: '**/IntelliTect.TestTools.TestFramework.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
-  version: '1.1.4'
+  version: '1.2.0'
 
 steps:
 - task: NuGetToolInstaller@0


### PR DESCRIPTION
At a client, I had to extract some common code out into an internal package, so I used some interface definitions to ensure cross-compatibility. To support that, I need to add a couple additional methods...
- AddDependencyService<TService, TImplemintation>()
- AddDependencyInstance<T>(object objToAdd()

So we can do things like:

AddDependencyService<IOracleConnection, SomeDatabaseClass>().