### PR TITLE
Change try/catch around JSON serialization to a general Exception catch

### DIFF
--- a/IntelliTect.TestTools.TestFramework.sln
+++ b/IntelliTect.TestTools.TestFramework.sln
@@ -10,6 +10,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IntelliTect.TestTools.TestFramework.Tests", "IntelliTect.TestTools.TestFramework\IntelliTect.TestTools.TestFramework.Tests\IntelliTect.TestTools.TestFramework.Tests.csproj", "{E64B6292-F8AF-475F-B45E-9BAB7D695579}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0114A621-A999-40EC-87C8-AF915A6E2DEC}"
+	ProjectSection(SolutionItems) = preProject
+		testframework-pipeline.yml = testframework-pipeline.yml
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework/TestBuilder.cs
+++ b/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework/TestBuilder.cs
@@ -220,7 +220,7 @@ namespace IntelliTect.TestTools.TestFramework
             catch (Exception e)
 #pragma warning restore CA1031 // Do not catch general exception types
             {
-                return $"Unable to serialize object {obj?.GetType()} to JSON. Mark the relevant property with the [JsonIgnore] attribute: {e.Message}";
+                return $"Unable to serialize object {obj?.GetType()} to JSON. Mark the relevant property with the [JsonIgnore] attribute: {e}";
             }
             
         }

--- a/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework/TestBuilder.cs
+++ b/IntelliTect.TestTools.TestFramework/IntelliTect.TestTools.TestFramework/TestBuilder.cs
@@ -208,12 +208,17 @@ namespace IntelliTect.TestTools.TestFramework
 
         private static string GetObjectDataAsJsonString(object obj)
         {
-
+            // JsonSerializer.Serialize has some different throw behavior between versions.
+            // One version threw an exception that occurred on a property, which happened to be a Selenium WebDriverException.
+            // In this one specific case, catch all exceptions and move on to provide standard behavior to all package consumers.
+            // TL;DR: we don't want logging failures to interrupt the test run.
             try
             {
                 return JsonSerializer.Serialize(obj, new JsonSerializerOptions { WriteIndented = true });
             }
-            catch (JsonException e)
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception e)
+#pragma warning restore CA1031 // Do not catch general exception types
             {
                 return $"Unable to serialize object {obj?.GetType()} to JSON. Mark the relevant property with the [JsonIgnore] attribute: {e.Message}";
             }

--- a/testframework-pipeline.yml
+++ b/testframework-pipeline.yml
@@ -13,7 +13,7 @@ variables:
   solution: '**/IntelliTect.TestTools.TestFramework.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
-  version: '1.2.0'
+  version: '1.2.1'
 
 steps:
 - task: NuGetToolInstaller@0


### PR DESCRIPTION
Long story short, I found some different behavior in how System.Text.Json's JsonSerializer.Serialize works. In one specific scenario (attempting to serialize an object results in a property on said object throwing an exception) I saw two different behaviors:
1) Throw a TargetInvocationException with an inner exception of whatever the object threw
2) Throw the original exception (in this case, it happened to be a Selenium WebDriverException)

To prevent having to explicitly catch just all of the exceptions, the code change is to catch a regular ol' Exception in this one specific case, because we don't want logging to behave different and risk stopping a test because some property couldn't be evaluated at log-time.