### PR TITLE
Add InitializeDatabase hook to allow database seeding

### DIFF
--- a/IntelliTect.TestTools.Data.Test/DatabaseFixture.SeedDatabaseOnInitialization.cs
+++ b/IntelliTect.TestTools.Data.Test/DatabaseFixture.SeedDatabaseOnInitialization.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using IntelliTect.IntelliTime.Data.Test.Util;
+using Xunit;
+
+namespace IntelliTect.TestTools.Data.Test
+{
+    public class DatabaseFixtureSeedDatabaseOnInitialization : IClassFixture<DatabaseFixture<SampleDbContext>>
+    {
+        private readonly DatabaseFixture<SampleDbContext> _DatabaseFixture;
+
+        public DatabaseFixtureSeedDatabaseOnInitialization(DatabaseFixture<SampleDbContext> dbFixture)
+        {
+            _DatabaseFixture = dbFixture ?? throw new ArgumentNullException(nameof(dbFixture));
+
+            _DatabaseFixture.InitializeDatabase = SeedData;
+        }
+
+        private Task SeedData(SampleDbContext dbContext)
+        {
+            var things = Enumerable.Range(1, 5).Select(_ => FakesFactory.Create<Person>());
+
+            dbContext.Persons.AddRange(things);
+
+            return dbContext.SaveChangesAsync();
+        }
+
+        [Fact]
+        public async Task DatabaseFixtureReused_SeedDataExists()
+        {
+            await _DatabaseFixture.PerformDatabaseOperation(context =>
+            {
+                Assert.Equal(5, context.Persons.Count());
+                Assert.False(context.Persons.Any(x => x == null));
+            });
+        }
+
+        [Fact]
+        public async Task DatabaseFixtureReused_SeedDataExists2()
+        {
+            await _DatabaseFixture.PerformDatabaseOperation(context =>
+            {
+                Assert.Equal(5, context.Persons.Count());
+                Assert.False(context.Persons.Any(x => x == null));
+            });
+        }
+    }
+}

--- a/IntelliTect.TestTools.Data/DatabaseFixture.cs
+++ b/IntelliTect.TestTools.Data/DatabaseFixture.cs
@@ -94,9 +94,9 @@ namespace IntelliTect.TestTools.Data
 
             await db.Database.EnsureCreatedAsync();
 
-            if (InitializeDatabase is not null)
+            if (InitializeDatabase is { } init)
             {
-                await InitializeDatabase(await CreateNewContext());
+                await init(await CreateNewContext());
             }
 
             return db;


### PR DESCRIPTION
- Add InitializeDatabase hook taking DbContext type as parameter, evaluated immediately after database is first constructed
  - This allows for easy placement of seed data code in cases where common data may be used across multiple tests within a class or across classes (Ex: XUnit IClassFixture or ICollectionFixture)